### PR TITLE
feat: add iOS verifier support for offline VC/VP over BLE

### DIFF
--- a/Sources/ios-tuvali-library/Verifier/Verifier.swift
+++ b/Sources/ios-tuvali-library/Verifier/Verifier.swift
@@ -1,15 +1,49 @@
 import Foundation
 
 @objc(Verifier)
-class Verifier: NSObject {
-    
+public class Verifier: NSObject {
+    @available(iOS 13.0, *)
+    private var bleCommunicator: VerifierBleCommunicator?
+    private let eventEmitter = EventEmitter.sharedInstance
+
+    public override init() {
+        super.init()
+        ErrorHandler.sharedInstance.setOnError(onError: self.handleError)
+    }
+
+    @available(iOS 13.0, *)
+    public func startAdvertisement(_ advIdentifier: String) -> String {
+        let communicator = VerifierBleCommunicator(eventEmitter: eventEmitter)
+        bleCommunicator = communicator
+        communicator.startAdvertisement(advIdentifier: advIdentifier)
+        return "OPENID4VP://connect?name=\(advIdentifier)&key=\(communicator.publicKey.toHex())"
+    }
+
+    @available(iOS 13.0, *)
+    public func disconnect() {
+        bleCommunicator?.stop()
+        bleCommunicator = nil
+    }
+
+    @available(iOS 13.0, *)
+    public func sendVerificationStatus(_ status: VerificationStatusEvent.VerificationStatus) {
+        bleCommunicator?.notifyVerificationStatus(accepted: status == .ACCEPTED)
+    }
+
+    public func subscribe(_ listener: @escaping (Event) -> Void) {
+        eventEmitter.addListener(listener: listener)
+    }
+
+    public func unsubscribe() {
+        eventEmitter.removeListeners()
+    }
+
     func getModuleName(completion: @escaping ([String]) -> Void) {
-            DispatchQueue.global(qos: .userInitiated).async {
-                completion(["iOS Verifier"])
-            }
+        DispatchQueue.global(qos: .userInitiated).async {
+            completion(["iOS Verifier"])
         }
-        
-    
+    }
+
     @objc
     static func requiresMainQueueSetup() -> Bool {
         return true
@@ -21,5 +55,9 @@ class Verifier: NSObject {
             "name": "verifier",
             "platform": "ios"
         ]
+    }
+
+    private func handleError(_ message: String, _ code: String) {
+        eventEmitter.emitErrorEvent(message: message, code: code)
     }
 }

--- a/Sources/ios-tuvali-library/Verifier/Verifier.swift
+++ b/Sources/ios-tuvali-library/Verifier/Verifier.swift
@@ -13,10 +13,12 @@ public class Verifier: NSObject {
 
     @available(iOS 13.0, *)
     public func startAdvertisement(_ advIdentifier: String) -> String {
+        bleCommunicator?.stop()
         let communicator = VerifierBleCommunicator(eventEmitter: eventEmitter)
         bleCommunicator = communicator
         communicator.startAdvertisement(advIdentifier: advIdentifier)
-        return "OPENID4VP://connect?name=\(advIdentifier)&key=\(communicator.publicKey.toHex())"
+        let encodedName = advIdentifier.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? advIdentifier
+        return "OPENID4VP://connect?name=\(encodedName)&key=\(communicator.publicKey.toHex())"
     }
 
     @available(iOS 13.0, *)

--- a/Sources/ios-tuvali-library/Verifier/VerifierBleCommunicator.swift
+++ b/Sources/ios-tuvali-library/Verifier/VerifierBleCommunicator.swift
@@ -1,0 +1,105 @@
+import Foundation
+import CoreBluetooth
+import Gzip
+
+@available(iOS 13.0, *)
+class VerifierBleCommunicator: NSObject {
+    private let eventEmitter: EventEmitter
+    private let verifierCryptoBox: VerifierCryptoBox
+    private let peripheral = Peripheral()
+    private lazy var transferHandler = VerifierTransferHandler(delegate: self)
+    private var secretsTranslator: SecretTranslator?
+    private(set) var publicKey: Data
+
+    init(eventEmitter: EventEmitter) {
+        self.eventEmitter = eventEmitter
+        self.verifierCryptoBox = VerifierCryptoBoxBuilder().build()
+        self.publicKey = verifierCryptoBox.getPublicKey()
+        super.init()
+    }
+
+    func startAdvertisement(advIdentifier: String) {
+        peripheral.start(advertisementName: advIdentifier, delegate: self)
+    }
+
+    func stop() {
+        peripheral.stop()
+    }
+
+    func notifyVerificationStatus(accepted: Bool) {
+        let status = accepted ? VerificationStatusEvent.VerificationStatus.ACCEPTED.rawValue : VerificationStatusEvent.VerificationStatus.REJECTED.rawValue
+        peripheral.sendData(charUUID: NetworkCharNums.VERIFICATION_STATUS_CHAR_UUID, data: Data([UInt8(status)]))
+    }
+
+    private func handleIdentifyRequest(_ data: Data) {
+        guard data.count >= CryptoConstants.NONCE_LENGTH + 32 else {
+            return
+        }
+
+        let nonce = data.subdata(in: 0..<CryptoConstants.NONCE_LENGTH)
+        let walletPublicKey = data.subdata(in: CryptoConstants.NONCE_LENGTH..<(CryptoConstants.NONCE_LENGTH + 32))
+        secretsTranslator = verifierCryptoBox.buildSecretsTranslator(nonce: nonce, walletPublicKey: walletPublicKey)
+        eventEmitter.emitEvent(SecureChannelEstablishedEvent())
+    }
+}
+
+@available(iOS 13.0, *)
+extension VerifierBleCommunicator: VerifierPeripheralDelegate {
+    func onPeripheralReady() {
+    }
+
+    func onAdvertisementStarted() {
+    }
+
+    func onDeviceConnected() {
+        eventEmitter.emitEvent(ConnectedEvent())
+    }
+
+    func onDeviceDisconnected() {
+        eventEmitter.emitEvent(DisconnectedEvent())
+    }
+
+    func onWrite(uuid: CBUUID, data: Data) {
+        switch uuid {
+        case NetworkCharNums.IDENTIFY_REQUEST_CHAR_UUID:
+            handleIdentifyRequest(data)
+        case NetworkCharNums.RESPONSE_SIZE_CHAR_UUID:
+            transferHandler.handleResponseSize(data, maxDataBytes: peripheral.maxDataBytes)
+        case NetworkCharNums.SUBMIT_RESPONSE_CHAR_UUID:
+            transferHandler.handleResponseChunk(data)
+        case NetworkCharNums.TRANSFER_REPORT_REQUEST_CHAR_UUID:
+            transferHandler.handleTransferReportRequest(data)
+        default:
+            break
+        }
+    }
+
+    func onNotificationSent(uuid: CBUUID, success: Bool) {
+    }
+}
+
+@available(iOS 13.0, *)
+extension VerifierBleCommunicator: VerifierTransferHandlerDelegate {
+    func sendDataOverNotification(charUUID: CBUUID, data: Data) {
+        peripheral.sendData(charUUID: charUUID, data: data)
+    }
+
+    func onResponseReceived(data: Data, crcFailureCount: Int, totalChunkCount: Int) {
+        guard let decryptedData = secretsTranslator?.decryptUponReceive(data: data),
+              let decompressedData = try? decryptedData.gunzipped(),
+              let payload = String(data: decompressedData, encoding: .utf8) else {
+            onResponseReceivedFailed("Verifier failed to decrypt or decompress response")
+            return
+        }
+
+        eventEmitter.emitEvent(DataReceivedEvent(
+            data: payload,
+            crcFailureCount: crcFailureCount,
+            totalChunkCount: totalChunkCount
+        ))
+    }
+
+    func onResponseReceivedFailed(_ message: String) {
+        eventEmitter.emitErrorEvent(message: message, code: VerifierErrorEnum.corruptedChunkReceived.code)
+    }
+}

--- a/Sources/ios-tuvali-library/Wallet/Wallet+Extension.swift
+++ b/Sources/ios-tuvali-library/Wallet/Wallet+Extension.swift
@@ -33,6 +33,18 @@ extension WalletBleCommunicator: WalletBleCommunicatorProtocol {
         }
     }
 
+    func shouldConnectToDiscoveredPeripheral(advertisementData: [String: Any]) -> Bool {
+        // iOS peripherals cannot advertise service data. For iOS verifier discovery,
+        // the QR URI carries the verifier public key and local name is only a hint.
+        guard verifierPublicKey != nil else {
+            return false
+        }
+        guard let advName, let localName = advertisementData[CBAdvertisementDataLocalNameKey] as? String else {
+            return true
+        }
+        return localName == advName
+    }
+
     func createConnectionHandler() {
         createConnection?()
     }
@@ -47,5 +59,4 @@ extension WalletBleCommunicator: TransferHandlerDelegate {
         }
     }
 }
-
 

--- a/Sources/ios-tuvali-library/Wallet/Wallet.swift
+++ b/Sources/ios-tuvali-library/Wallet/Wallet.swift
@@ -19,6 +19,8 @@ public class Wallet: WalletProtocol {
 
         bleCommunicator = WalletBleCommunicator()
         bleCommunicator?.setAdvIdentifier(identifier: advPayload)
+        bleCommunicator?.setVerifierPublicKey(publicKeyData: hexStringToData(string: openId4VpURI.getHexPK()!))
+        bleCommunicator?.setAdvName(openId4VpURI.getName())
         bleCommunicator?.startScanning()
         bleCommunicator?.createConnection = {
             EventEmitter.sharedInstance.emitEvent(ConnectedEvent())

--- a/Sources/ios-tuvali-library/Wallet/WalletBleCommunicator.swift
+++ b/Sources/ios-tuvali-library/Wallet/WalletBleCommunicator.swift
@@ -9,6 +9,7 @@ class WalletBleCommunicator: NSObject {
     var secretTranslator: SecretTranslator?
     var cryptoBox: WalletCryptoBox = WalletCryptoBoxBuilder().build()
     var advIdentifier: Data?
+    var advName: String?
     var verifierPublicKey: Data?
     var createConnection: (() -> Void)?
     static let EXCHANGE_RECEIVER_INFO_DATA = "{\"deviceName\":\"Verifier\"}"
@@ -21,6 +22,10 @@ class WalletBleCommunicator: NSObject {
 
     func setAdvIdentifier(identifier: Data) {
         self.advIdentifier = identifier
+    }
+
+    func setAdvName(_ name: String?) {
+        self.advName = name
     }
 
     func setVerifierPublicKey(publicKeyData: Data) {

--- a/Sources/ios-tuvali-library/ble/Utility/Assembler.swift
+++ b/Sources/ios-tuvali-library/ble/Utility/Assembler.swift
@@ -11,6 +11,10 @@ class Assembler {
         self.maxDataBytes = maxDataBytes
         self.data = Data(repeating: 0, count: totalSize)
         let effectivePayloadSize = maxDataBytes - chunkMetaSize
+        guard effectivePayloadSize > 0 else {
+            self.chunkReceivedMarker = []
+            return
+        }
         let totalChunks = Int(ceil(Double(totalSize) / Double(effectivePayloadSize)))
         self.chunkReceivedMarker = Array(repeating: false, count: max(totalChunks, 0))
     }

--- a/Sources/ios-tuvali-library/ble/Utility/Assembler.swift
+++ b/Sources/ios-tuvali-library/ble/Utility/Assembler.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+class Assembler {
+    private let maxDataBytes: Int
+    private let chunkMetaSize = BLEConstants.seqNumberReservedByteSize + BLEConstants.mtuReservedByteSize
+    private var data: Data
+    private var chunkReceivedMarker: [Bool]
+    private(set) var crcFailureCount = 0
+
+    init(totalSize: Int, maxDataBytes: Int) {
+        self.maxDataBytes = maxDataBytes
+        self.data = Data(repeating: 0, count: totalSize)
+        let effectivePayloadSize = maxDataBytes - chunkMetaSize
+        let totalChunks = Int(ceil(Double(totalSize) / Double(effectivePayloadSize)))
+        self.chunkReceivedMarker = Array(repeating: false, count: max(totalChunks, 0))
+    }
+
+    var totalChunkCount: Int {
+        return chunkReceivedMarker.count
+    }
+
+    func addChunk(_ chunkData: Data) {
+        guard chunkData.count >= chunkMetaSize, chunkData.count <= maxDataBytes else {
+            return
+        }
+
+        let seqNumber = Util.networkOrderedByteArrayToInt(num: chunkData.subdata(in: 0..<2))
+        let crcReceived = UInt16(Util.networkOrderedByteArrayToInt(num: chunkData.subdata(in: 2..<4)))
+        let payload = chunkData.subdata(in: 4..<chunkData.count)
+
+        guard CRC.verify(d: payload, expected: crcReceived) else {
+            crcFailureCount += 1
+            return
+        }
+
+        let seqIndex = seqNumber.toSeqIndex()
+        guard seqIndex >= 0, seqIndex < chunkReceivedMarker.count else {
+            return
+        }
+
+        let effectivePayloadSize = maxDataBytes - chunkMetaSize
+        let start = seqIndex * effectivePayloadSize
+        let end = min(start + payload.count, data.count)
+        guard start < end else {
+            return
+        }
+
+        data.replaceSubrange(start..<end, with: payload.prefix(end - start))
+        chunkReceivedMarker[seqIndex] = true
+    }
+
+    func isComplete() -> Bool {
+        return !chunkReceivedMarker.contains(false)
+    }
+
+    func missedSequenceNumbers() -> [Int] {
+        return chunkReceivedMarker.enumerated().compactMap { index, received in
+            received ? nil : index.toSeqNumber()
+        }
+    }
+
+    func assembledData() -> Data {
+        return data
+    }
+}

--- a/Sources/ios-tuvali-library/ble/Utility/TransferReport.swift
+++ b/Sources/ios-tuvali-library/ble/Utility/TransferReport.swift
@@ -43,5 +43,16 @@ class TransferReport  {
             totalPages = 0
         }
     }
-}
 
+    func toBytes(maxDataBytes: Int) -> Data {
+        let sequenceCapacity = max((maxDataBytes - 3) / 2, 0)
+        let sequences = Array((missingSequences ?? []).prefix(sequenceCapacity))
+        let pageCount = sequences.isEmpty ? 0 : Int(ceil(Double((missingSequences ?? []).count) / Double(max(sequenceCapacity, 1))))
+        var bytes = Data([UInt8(type.rawValue)])
+        bytes.append(Util.intToNetworkOrderedByteArray(num: pageCount, byteCount: .TwoBytes))
+        sequences.forEach { sequence in
+            bytes.append(Util.intToNetworkOrderedByteArray(num: sequence, byteCount: .TwoBytes))
+        }
+        return bytes
+    }
+}

--- a/Sources/ios-tuvali-library/ble/Utility/VerifierTransferHandler.swift
+++ b/Sources/ios-tuvali-library/ble/Utility/VerifierTransferHandler.swift
@@ -24,7 +24,11 @@ class VerifierTransferHandler {
             return
         }
         self.maxDataBytes = maxDataBytes
-        let responseSize = Int(UInt32(bigEndian: data.withUnsafeBytes { $0.load(as: UInt32.self) }))
+        var beSize: UInt32 = 0
+        _ = withUnsafeMutableBytes(of: &beSize) { dst in
+            data.copyBytes(to: dst)
+        }
+        let responseSize = Int(UInt32(bigEndian: beSize))
         guard responseSize > 0 else {
             delegate?.onResponseReceivedFailed("Verifier received empty response")
             return

--- a/Sources/ios-tuvali-library/ble/Utility/VerifierTransferHandler.swift
+++ b/Sources/ios-tuvali-library/ble/Utility/VerifierTransferHandler.swift
@@ -1,0 +1,76 @@
+import Foundation
+import CoreBluetooth
+
+@available(iOS 13.0, *)
+protocol VerifierTransferHandlerDelegate: AnyObject {
+    func sendDataOverNotification(charUUID: CBUUID, data: Data)
+    func onResponseReceived(data: Data, crcFailureCount: Int, totalChunkCount: Int)
+    func onResponseReceivedFailed(_ message: String)
+}
+
+@available(iOS 13.0, *)
+class VerifierTransferHandler {
+    private weak var delegate: VerifierTransferHandlerDelegate?
+    private var assembler: Assembler?
+    private var maxDataBytes = BLEConstants.MAX_ALLOWED_DATA_LEN
+
+    init(delegate: VerifierTransferHandlerDelegate) {
+        self.delegate = delegate
+    }
+
+    func handleResponseSize(_ data: Data, maxDataBytes: Int) {
+        guard data.count == 4 else {
+            delegate?.onResponseReceivedFailed("Verifier received invalid response size")
+            return
+        }
+        self.maxDataBytes = maxDataBytes
+        let responseSize = Int(UInt32(bigEndian: data.withUnsafeBytes { $0.load(as: UInt32.self) }))
+        guard responseSize > 0 else {
+            delegate?.onResponseReceivedFailed("Verifier received empty response")
+            return
+        }
+        assembler = Assembler(totalSize: responseSize, maxDataBytes: maxDataBytes)
+    }
+
+    func handleResponseChunk(_ data: Data) {
+        guard let assembler, !assembler.isComplete() else {
+            return
+        }
+        assembler.addChunk(data)
+    }
+
+    func handleTransferReportRequest(_ data: Data) {
+        guard let reportType = data.first else {
+            return
+        }
+
+        if reportType == UInt8(SemaphoreMarker.Error.rawValue) {
+            delegate?.onResponseReceivedFailed("Wallet reported an error during transfer")
+            return
+        }
+
+        guard reportType == UInt8(SemaphoreMarker.RequestReport.rawValue), let assembler else {
+            return
+        }
+
+        if assembler.isComplete() {
+            let report = TransferReport(type: .SUCCESS, totalPages: 0, missingSequences: [])
+            delegate?.sendDataOverNotification(charUUID: NetworkCharNums.TRANSFER_REPORT_RESPONSE_CHAR_UUID, data: report.toBytes(maxDataBytes: maxDataBytes))
+            delegate?.onResponseReceived(
+                data: assembler.assembledData(),
+                crcFailureCount: assembler.crcFailureCount,
+                totalChunkCount: assembler.totalChunkCount
+            )
+            return
+        }
+
+        let missed = assembler.missedSequenceNumbers()
+        if Double(missed.count) > (0.7 * Double(assembler.totalChunkCount)) {
+            delegate?.onResponseReceivedFailed("Failing transfer as missing chunks are more than 70% of total chunks")
+            return
+        }
+
+        let report = TransferReport(type: .MISSING_CHUNKS, totalPages: 1, missingSequences: missed)
+        delegate?.sendDataOverNotification(charUUID: NetworkCharNums.TRANSFER_REPORT_RESPONSE_CHAR_UUID, data: report.toBytes(maxDataBytes: maxDataBytes))
+    }
+}

--- a/Sources/ios-tuvali-library/ble/central/CentralManagerDelegate.swift
+++ b/Sources/ios-tuvali-library/ble/central/CentralManagerDelegate.swift
@@ -17,6 +17,10 @@ extension Central {
                 central.connect(peripheral)
                 connectedPeripheral = peripheral
             }
+        } else if walletBleCommunicatorDelegate?.shouldConnectToDiscoveredPeripheral(advertisementData: advertisementData) == true {
+            peripheral.delegate = self
+            central.connect(peripheral)
+            connectedPeripheral = peripheral
         }
     }
 

--- a/Sources/ios-tuvali-library/ble/central/PeripheralDelegate.swift
+++ b/Sources/ios-tuvali-library/ble/central/PeripheralDelegate.swift
@@ -50,9 +50,9 @@ extension Central: CBPeripheralDelegate {
         for characteristic in serviceCharacteristics {
             self.cbCharacteristics[characteristic.uuid.uuidString] = characteristic
             if characteristic.uuid == NetworkCharNums.TRANSFER_REPORT_RESPONSE_CHAR_UUID ||
-                characteristic.uuid == NetworkCharNums.VERIFICATION_STATUS_CHAR_UUID || characteristic.uuid == NetworkCharNums.DISCONNECT_CHAR_UUID
+                characteristic.uuid == NetworkCharNums.VERIFICATION_STATUS_CHAR_UUID || characteristic.uuid == NetworkCharNums.DISCONNECT_CHAR_UUID
             {
-                peripheral.setNotifyValue(true, for: characteristic)
+                peripheral.setNotifyValue(true, for: characteristic)
             }
         }
         walletBleCommunicatorDelegate?.createConnectionHandler()

--- a/Sources/ios-tuvali-library/ble/peripheral/Characteristics.swift
+++ b/Sources/ios-tuvali-library/ble/peripheral/Characteristics.swift
@@ -20,6 +20,8 @@ struct CBcharatcteristic {
     let transferReportResponseChar = CBMutableCharacteristic(type: CBUUID(string: CharacteristicIds.TRANSFER_REPORT_RESPONSE_CHAR_UUID.rawValue), properties: characteristicsMap[CharacteristicIds.TRANSFER_REPORT_RESPONSE_CHAR_UUID.rawValue]!.properties, value: characteristicsMap[CharacteristicIds.TRANSFER_REPORT_RESPONSE_CHAR_UUID.rawValue]!.value, permissions: characteristicsMap[CharacteristicIds.TRANSFER_REPORT_RESPONSE_CHAR_UUID.rawValue]!.permissions)
 
     let verificationStatusChar = CBMutableCharacteristic(type: CBUUID(string: CharacteristicIds.VERIFICATION_STATUS_CHAR_UUID.rawValue), properties: characteristicsMap[CharacteristicIds.VERIFICATION_STATUS_CHAR_UUID.rawValue]!.properties, value: characteristicsMap[CharacteristicIds.VERIFICATION_STATUS_CHAR_UUID.rawValue]!.value, permissions: characteristicsMap[CharacteristicIds.VERIFICATION_STATUS_CHAR_UUID.rawValue]!.permissions)
+
+    let disconnectChar = CBMutableCharacteristic(type: CBUUID(string: CharacteristicIds.DISCONNECT_CHAR_UUID.rawValue), properties: characteristicsMap[CharacteristicIds.DISCONNECT_CHAR_UUID.rawValue]!.properties, value: characteristicsMap[CharacteristicIds.DISCONNECT_CHAR_UUID.rawValue]!.value, permissions: characteristicsMap[CharacteristicIds.DISCONNECT_CHAR_UUID.rawValue]!.permissions)
 }
 
 // TODO: Add conn status change everywhere
@@ -45,6 +47,7 @@ let characteristicsMap: [String: CharacteristicTuple] = [
     "00000009-5026-444A-9E0E-D6F2450F3A77": (properties: CBCharacteristicProperties([.writeWithoutResponse, .write]), permissions: CBAttributePermissions([.writeable]), value: nil),
     "0000000A-5026-444A-9E0E-D6F2450F3A77": (properties: CBCharacteristicProperties([.indicate]), permissions: CBAttributePermissions([.readable]), value: nil),
     "00002037-0000-1000-8000-00805f9b34fb": (properties: CBCharacteristicProperties([.indicate]), permissions: CBAttributePermissions([.readable]), value: nil),
+    "0000000B-5026-444A-9E0E-D6F2450F3A77": (properties: CBCharacteristicProperties([.indicate]), permissions: CBAttributePermissions([.readable]), value: nil),
 ]
 
 struct NetworkCharNums {
@@ -69,6 +72,5 @@ enum NotificationEvent: String {
     case DISCONNECT_STATUS_CHANGE = "DISCONNECT_STATUS_CHANGE"
     case ERROR = "ERROR"
 }
-
 
 

--- a/Sources/ios-tuvali-library/ble/peripheral/Peripheral.swift
+++ b/Sources/ios-tuvali-library/ble/peripheral/Peripheral.swift
@@ -17,7 +17,7 @@ class Peripheral: NSObject {
     weak var verifierDelegate: VerifierPeripheralDelegate?
     private var characteristics: [String: CBMutableCharacteristic] = [:]
     var pendingAdvertisementName: String?
-    private var serviceAdded = false
+    var serviceAdded = false
     var maxDataBytes = BLEConstants.MAX_ALLOWED_DATA_LEN
 
     static let SERVICE_UUID = CBUUID(string: "00000001-0000-1000-8000-00805f9b34fb")
@@ -57,7 +57,6 @@ class Peripheral: NSObject {
         }
         bleService.characteristics = mutableCharacteristics
         peripheralManager.add(bleService)
-        serviceAdded = true
     }
 
     func sendData(charUUID: CBUUID, data: Data) {

--- a/Sources/ios-tuvali-library/ble/peripheral/Peripheral.swift
+++ b/Sources/ios-tuvali-library/ble/peripheral/Peripheral.swift
@@ -2,8 +2,23 @@ import Foundation
 import CoreBluetooth
 
 @available(iOS 13.0, *)
+protocol VerifierPeripheralDelegate: AnyObject {
+    func onPeripheralReady()
+    func onAdvertisementStarted()
+    func onDeviceConnected()
+    func onDeviceDisconnected()
+    func onWrite(uuid: CBUUID, data: Data)
+    func onNotificationSent(uuid: CBUUID, success: Bool)
+}
+
+@available(iOS 13.0, *)
 class Peripheral: NSObject {
-    private var peripheralManager: CBPeripheralManager!
+    var peripheralManager: CBPeripheralManager!
+    weak var verifierDelegate: VerifierPeripheralDelegate?
+    private var characteristics: [String: CBMutableCharacteristic] = [:]
+    var pendingAdvertisementName: String?
+    private var serviceAdded = false
+    var maxDataBytes = BLEConstants.MAX_ALLOWED_DATA_LEN
 
     static let SERVICE_UUID = CBUUID(string: "00000001-0000-1000-8000-00805f9b34fb")
     static let SCAN_RESPONSE_SERVICE_UUID = CBUUID(string: "00000002-0000-1000-8000-00805f9b34fb")
@@ -13,10 +28,53 @@ class Peripheral: NSObject {
         peripheralManager = CBPeripheralManager(delegate: self, queue: nil, options: [CBPeripheralManagerOptionShowPowerAlertKey: true])
     }
 
+    func start(advertisementName: String, delegate: VerifierPeripheralDelegate) {
+        self.verifierDelegate = delegate
+        self.pendingAdvertisementName = advertisementName
+        if peripheralManager.state == .poweredOn {
+            setupPeripheralsAndStartAdvertising()
+        }
+    }
+
+    func stop() {
+        peripheralManager.stopAdvertising()
+        peripheralManager.removeAllServices()
+        serviceAdded = false
+        characteristics.removeAll()
+        verifierDelegate?.onDeviceDisconnected()
+    }
+
     func setupPeripheralsAndStartAdvertising() {
+        guard !serviceAdded else {
+            startAdvertisingIfPossible()
+            return
+        }
+
         let bleService = CBMutableService(type: Self.SERVICE_UUID, primary: true)
-        bleService.characteristics = Util.createCBMutableCharacteristics()
+        let mutableCharacteristics = Util.createCBMutableCharacteristics()
+        mutableCharacteristics.forEach { characteristic in
+            characteristics[characteristic.uuid.uuidString] = characteristic
+        }
+        bleService.characteristics = mutableCharacteristics
         peripheralManager.add(bleService)
-        peripheralManager.startAdvertising([CBAdvertisementDataServiceUUIDsKey: [Self.SERVICE_UUID, Self.SCAN_RESPONSE_SERVICE_UUID], CBAdvertisementDataLocalNameKey: "verifier"])
+        serviceAdded = true
+    }
+
+    func sendData(charUUID: CBUUID, data: Data) {
+        guard let characteristic = characteristics[charUUID.uuidString] else {
+            return
+        }
+        let success = peripheralManager.updateValue(data, for: characteristic, onSubscribedCentrals: nil)
+        verifierDelegate?.onNotificationSent(uuid: charUUID, success: success)
+    }
+
+    private func startAdvertisingIfPossible() {
+        guard let pendingAdvertisementName else {
+            return
+        }
+        peripheralManager.startAdvertising([
+            CBAdvertisementDataServiceUUIDsKey: [Self.SERVICE_UUID],
+            CBAdvertisementDataLocalNameKey: pendingAdvertisementName
+        ])
     }
 }

--- a/Sources/ios-tuvali-library/ble/peripheral/PeripheralCommunicatorDelegate.swift
+++ b/Sources/ios-tuvali-library/ble/peripheral/PeripheralCommunicatorDelegate.swift
@@ -13,5 +13,6 @@ protocol WalletBleCommunicatorProtocol: AnyObject {
     func onDisconnectStatusChange(data: Data?)
     func createConnectionHandler()
     func setVeriferKeyOnSameIdentifier(payload: Data, publicData: Data, completion: (() -> Void))
+    func shouldConnectToDiscoveredPeripheral(advertisementData: [String: Any]) -> Bool
     func onDisconnect()
 }

--- a/Sources/ios-tuvali-library/ble/peripheral/PeripheralExtension.swift
+++ b/Sources/ios-tuvali-library/ble/peripheral/PeripheralExtension.swift
@@ -18,14 +18,41 @@ extension Peripheral: CBPeripheralManagerDelegate {
     
     func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didSubscribeTo characteristic: CBCharacteristic) {
         os_log(.info, "Central subscribed to characteristic")
+        maxDataBytes = min(central.maximumUpdateValueLength, BLEConstants.MAX_ALLOWED_DATA_LEN)
+        verifierDelegate?.onDeviceConnected()
         peripheral.stopAdvertising()
     }
     
     func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didUnsubscribeFrom characteristic: CBCharacteristic) {
         os_log(.info, "Central unsubscribed from characteristic")
+        verifierDelegate?.onDeviceDisconnected()
     }
     
     func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite requests: [CBATTRequest]) {
         os_log(.info, "Received write request for characteristic")
+        requests.forEach { request in
+            verifierDelegate?.onWrite(uuid: request.characteristic.uuid, data: request.value ?? Data())
+            peripheral.respond(to: request, withResult: .success)
+        }
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
+        guard error == nil else {
+            os_log(.error, "Failed to add verifier GATT service")
+            return
+        }
+        verifierDelegate?.onPeripheralReady()
+        peripheral.startAdvertising([
+            CBAdvertisementDataServiceUUIDsKey: [Peripheral.SERVICE_UUID],
+            CBAdvertisementDataLocalNameKey: pendingAdvertisementName ?? "verifier"
+        ])
+    }
+
+    func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
+        guard error == nil else {
+            os_log(.error, "Failed to start verifier advertisement")
+            return
+        }
+        verifierDelegate?.onAdvertisementStarted()
     }
 }

--- a/Sources/ios-tuvali-library/ble/peripheral/PeripheralExtension.swift
+++ b/Sources/ios-tuvali-library/ble/peripheral/PeripheralExtension.swift
@@ -39,8 +39,10 @@ extension Peripheral: CBPeripheralManagerDelegate {
     func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
         guard error == nil else {
             os_log(.error, "Failed to add verifier GATT service")
+            serviceAdded = false
             return
         }
+        serviceAdded = true
         verifierDelegate?.onPeripheralReady()
         peripheral.startAdvertising([
             CBAdvertisementDataServiceUUIDsKey: [Peripheral.SERVICE_UUID],

--- a/Sources/ios-tuvali-library/common/events/DataReceivedEvent.swift
+++ b/Sources/ios-tuvali-library/common/events/DataReceivedEvent.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct DataReceivedEvent: Event {
+    public let data: String
+    public let crcFailureCount: Int
+    public let totalChunkCount: Int
+
+    public init(data: String, crcFailureCount: Int = 0, totalChunkCount: Int = 0) {
+        self.data = data
+        self.crcFailureCount = crcFailureCount
+        self.totalChunkCount = totalChunkCount
+    }
+}

--- a/Sources/ios-tuvali-library/common/events/ErrorEvent.swift
+++ b/Sources/ios-tuvali-library/common/events/ErrorEvent.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public struct ErrorEvent: Event {
-    var message: String
-    var code: String
+    public var message: String
+    public var code: String
 }
-

--- a/Sources/ios-tuvali-library/crypto/Verifier/VerifierCryptoBox.swift
+++ b/Sources/ios-tuvali-library/crypto/Verifier/VerifierCryptoBox.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@available(iOS 13.0, *)
+protocol VerifierCryptoBox {
+    func getPublicKey() -> Data
+    func buildSecretsTranslator(nonce: Data, walletPublicKey: Data) -> SecretTranslator
+}

--- a/Sources/ios-tuvali-library/crypto/Verifier/VerifierCryptoBoxBuilder.swift
+++ b/Sources/ios-tuvali-library/crypto/Verifier/VerifierCryptoBoxBuilder.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+@available(iOS 13.0, *)
+class VerifierCryptoBoxBuilder {
+    func build() -> VerifierCryptoBox {
+        return VerifierCryptoBoxImpl()
+    }
+}

--- a/Sources/ios-tuvali-library/crypto/Verifier/VerifierCryptoBoxImpl.swift
+++ b/Sources/ios-tuvali-library/crypto/Verifier/VerifierCryptoBoxImpl.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@available(iOS 13.0, *)
+class VerifierCryptoBoxImpl: VerifierCryptoBox {
+    private let selfCryptoBox = CryptoBoxImpl()
+
+    func getPublicKey() -> Data {
+        return selfCryptoBox.getPublicKey()
+    }
+
+    func buildSecretsTranslator(nonce: Data, walletPublicKey: Data) -> SecretTranslator {
+        let cipherPackage = selfCryptoBox.createCipherPackage(
+            otherPublicKey: walletPublicKey,
+            senderInfo: CryptoConstants.VERIFIER_INFO,
+            recieverInfo: CryptoConstants.WALLET_INFO,
+            nonceBytes: nonce
+        )
+        return SenderTransferOwnershipOfData(CipherPackage: cipherPackage, nonce: nonce)
+    }
+}

--- a/Tests/ios-tuvali-libraryTests/ios_tuvali_libraryTests.swift
+++ b/Tests/ios-tuvali-libraryTests/ios_tuvali_libraryTests.swift
@@ -1,11 +1,108 @@
 import XCTest
+import CoreBluetooth
 @testable import ios_tuvali_library
+
+class MockVerifierTransferHandlerDelegate: VerifierTransferHandlerDelegate {
+    var sentData: [(charUUID: CBUUID, data: Data)] = []
+    var receivedData: Data?
+    var receivedCrcFailureCount: Int?
+    var receivedTotalChunkCount: Int?
+    var failedMessage: String?
+
+    func sendDataOverNotification(charUUID: CBUUID, data: Data) {
+        sentData.append((charUUID, data))
+    }
+
+    func onResponseReceived(data: Data, crcFailureCount: Int, totalChunkCount: Int) {
+        receivedData = data
+        receivedCrcFailureCount = crcFailureCount
+        receivedTotalChunkCount = totalChunkCount
+    }
+
+    func onResponseReceivedFailed(_ message: String) {
+        failedMessage = message
+    }
+}
 
 final class ios_tuvali_libraryTests: XCTestCase {
     func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
         XCTAssertEqual(ios_tuvali_library().text, "Hello, World!")
     }
+
+    func testAssemblerInitializationWithLowMaxDataBytes() {
+        // maxDataBytes (3) <= chunkMetaSize (4)
+        let assembler = Assembler(totalSize: 100, maxDataBytes: 3)
+        XCTAssertEqual(assembler.totalChunkCount, 0)
+        XCTAssertTrue(assembler.isComplete())
+        
+        // Verify addChunk does not crash
+        let dummyChunk = Data([0x00, 0x01, 0x02])
+        assembler.addChunk(dummyChunk)
+        XCTAssertEqual(assembler.crcFailureCount, 0)
+    }
+
+    func testAssemblerInitializationWithNormalMaxDataBytes() {
+        // maxDataBytes (20) > chunkMetaSize (4), effective payload size = 16
+        // totalSize = 32, so totalChunks = 32 / 16 = 2
+        let assembler = Assembler(totalSize: 32, maxDataBytes: 20)
+        XCTAssertEqual(assembler.totalChunkCount, 2)
+        XCTAssertFalse(assembler.isComplete())
+    }
+
+    func testVerifierTransferHandlerResponseSizeParsing() {
+        let mockDelegate = MockVerifierTransferHandlerDelegate()
+        let handler = VerifierTransferHandler(delegate: mockDelegate)
+        
+        // 1. Valid size: 100 bytes (big endian UInt32 = 0x00000064)
+        let validData = Data([0x00, 0x00, 0x00, 0x64])
+        handler.handleResponseSize(validData, maxDataBytes: 20)
+        XCTAssertNil(mockDelegate.failedMessage)
+        
+        // 2. Invalid size (not 4 bytes)
+        let invalidData = Data([0x00, 0x00, 0x64])
+        handler.handleResponseSize(invalidData, maxDataBytes: 20)
+        XCTAssertEqual(mockDelegate.failedMessage, "Verifier received invalid response size")
+        
+        // Reset failed message
+        mockDelegate.failedMessage = nil
+        
+        // 3. Size <= 0
+        let zeroData = Data([0x00, 0x00, 0x00, 0x00])
+        handler.handleResponseSize(zeroData, maxDataBytes: 20)
+        XCTAssertEqual(mockDelegate.failedMessage, "Verifier received empty response")
+    }
+
+    func testVerifierUrlEncoding() {
+        let verifier = Verifier()
+        // Test advertising identifier with special characters and spaces
+        let advName = "Test Name!@# 123"
+        let uri = verifier.startAdvertisement(advName)
+        
+        // Check that the returned URI is formatted correctly
+        XCTAssertTrue(uri.hasPrefix("OPENID4VP://connect?"))
+        
+        // Parse the URI using URLComponents to verify components
+        guard let components = URLComponents(string: uri) else {
+            XCTFail("Failed to parse URI: \(uri)")
+            return
+        }
+        
+        let nameQueryItem = components.queryItems?.first(where: { $0.name == "name" })
+        XCTAssertNotNil(nameQueryItem)
+        XCTAssertEqual(nameQueryItem?.value, advName)
+        
+        // Ensure that in the raw URI string, spaces and special characters are encoded
+        XCTAssertTrue(uri.contains("Test%20Name"))
+    }
+
+    func testVerifierDisconnect() {
+        let verifier = Verifier()
+        // Should not crash when bleCommunicator is nil
+        verifier.disconnect()
+        
+        _ = verifier.startAdvertisement("TestDevice")
+        // Should stop the advertising and clear communicator without crash
+        verifier.disconnect()
+    }
 }
+

--- a/example/demo-ios-app/demo-app-tuvali.xcodeproj/project.pbxproj
+++ b/example/demo-ios-app/demo-app-tuvali.xcodeproj/project.pbxproj
@@ -1,0 +1,670 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9C43FD142BB6AA7C001C5F6F /* ios-tuvali-library in Frameworks */ = {isa = PBXBuildFile; productRef = 9C43FD132BB6AA7C001C5F6F /* ios-tuvali-library */; };
+		9C9A70952BAAAEB600EF9D0E /* demo_app_tuvaliApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A70942BAAAEB600EF9D0E /* demo_app_tuvaliApp.swift */; };
+		9C9A70972BAAAEB600EF9D0E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A70962BAAAEB600EF9D0E /* ContentView.swift */; };
+		9C9A70992BAAAEB900EF9D0E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9C9A70982BAAAEB900EF9D0E /* Assets.xcassets */; };
+		9C9A709D2BAAAEB900EF9D0E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9C9A709C2BAAAEB900EF9D0E /* Preview Assets.xcassets */; };
+		9C9A70A72BAAAEB900EF9D0E /* demo_app_tuvaliTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A70A62BAAAEB900EF9D0E /* demo_app_tuvaliTests.swift */; };
+		9C9A70B12BAAAEB900EF9D0E /* demo_app_tuvaliUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A70B02BAAAEB900EF9D0E /* demo_app_tuvaliUITests.swift */; };
+		9C9A70B32BAAAEB900EF9D0E /* demo_app_tuvaliUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A70B22BAAAEB900EF9D0E /* demo_app_tuvaliUITestsLaunchTests.swift */; };
+		9CF43DEF2BB6B556008CB8B1 /* ios-tuvali-library in Frameworks */ = {isa = PBXBuildFile; productRef = 9CF43DEE2BB6B556008CB8B1 /* ios-tuvali-library */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		9C9A70A32BAAAEB900EF9D0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9C9A70892BAAAEB600EF9D0E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9C9A70902BAAAEB600EF9D0E;
+			remoteInfo = "demo-app-tuvali";
+		};
+		9C9A70AD2BAAAEB900EF9D0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9C9A70892BAAAEB600EF9D0E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9C9A70902BAAAEB600EF9D0E;
+			remoteInfo = "demo-app-tuvali";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9C9A70CF2BAADC8800EF9D0E /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9C9A70D92BAAE40B00EF9D0E /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		9C9A70912BAAAEB600EF9D0E /* demo-app-tuvali.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "demo-app-tuvali.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C9A70942BAAAEB600EF9D0E /* demo_app_tuvaliApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = demo_app_tuvaliApp.swift; sourceTree = "<group>"; };
+		9C9A70962BAAAEB600EF9D0E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		9C9A70982BAAAEB900EF9D0E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9C9A709A2BAAAEB900EF9D0E /* demo_app_tuvali.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = demo_app_tuvali.entitlements; sourceTree = "<group>"; };
+		9C9A709C2BAAAEB900EF9D0E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		9C9A70A22BAAAEB900EF9D0E /* demo-app-tuvaliTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "demo-app-tuvaliTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C9A70A62BAAAEB900EF9D0E /* demo_app_tuvaliTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = demo_app_tuvaliTests.swift; sourceTree = "<group>"; };
+		9C9A70AC2BAAAEB900EF9D0E /* demo-app-tuvaliUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "demo-app-tuvaliUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C9A70B02BAAAEB900EF9D0E /* demo_app_tuvaliUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = demo_app_tuvaliUITests.swift; sourceTree = "<group>"; };
+		9C9A70B22BAAAEB900EF9D0E /* demo_app_tuvaliUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = demo_app_tuvaliUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9C9A708E2BAAAEB600EF9D0E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C43FD142BB6AA7C001C5F6F /* ios-tuvali-library in Frameworks */,
+				9CF43DEF2BB6B556008CB8B1 /* ios-tuvali-library in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9C9A709F2BAAAEB900EF9D0E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9C9A70A92BAAAEB900EF9D0E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9C9A70882BAAAEB600EF9D0E = {
+			isa = PBXGroup;
+			children = (
+				9C9A70932BAAAEB600EF9D0E /* demo-app-tuvali */,
+				9C9A70A52BAAAEB900EF9D0E /* demo-app-tuvaliTests */,
+				9C9A70AF2BAAAEB900EF9D0E /* demo-app-tuvaliUITests */,
+				9C9A70922BAAAEB600EF9D0E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9C9A70922BAAAEB600EF9D0E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9C9A70912BAAAEB600EF9D0E /* demo-app-tuvali.app */,
+				9C9A70A22BAAAEB900EF9D0E /* demo-app-tuvaliTests.xctest */,
+				9C9A70AC2BAAAEB900EF9D0E /* demo-app-tuvaliUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9C9A70932BAAAEB600EF9D0E /* demo-app-tuvali */ = {
+			isa = PBXGroup;
+			children = (
+				9C9A70942BAAAEB600EF9D0E /* demo_app_tuvaliApp.swift */,
+				9C9A70962BAAAEB600EF9D0E /* ContentView.swift */,
+				9C9A70982BAAAEB900EF9D0E /* Assets.xcassets */,
+				9C9A709A2BAAAEB900EF9D0E /* demo_app_tuvali.entitlements */,
+				9C9A709B2BAAAEB900EF9D0E /* Preview Content */,
+			);
+			path = "demo-app-tuvali";
+			sourceTree = "<group>";
+		};
+		9C9A709B2BAAAEB900EF9D0E /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				9C9A709C2BAAAEB900EF9D0E /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		9C9A70A52BAAAEB900EF9D0E /* demo-app-tuvaliTests */ = {
+			isa = PBXGroup;
+			children = (
+				9C9A70A62BAAAEB900EF9D0E /* demo_app_tuvaliTests.swift */,
+			);
+			path = "demo-app-tuvaliTests";
+			sourceTree = "<group>";
+		};
+		9C9A70AF2BAAAEB900EF9D0E /* demo-app-tuvaliUITests */ = {
+			isa = PBXGroup;
+			children = (
+				9C9A70B02BAAAEB900EF9D0E /* demo_app_tuvaliUITests.swift */,
+				9C9A70B22BAAAEB900EF9D0E /* demo_app_tuvaliUITestsLaunchTests.swift */,
+			);
+			path = "demo-app-tuvaliUITests";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9C9A70902BAAAEB600EF9D0E /* demo-app-tuvali */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9C9A70B62BAAAEB900EF9D0E /* Build configuration list for PBXNativeTarget "demo-app-tuvali" */;
+			buildPhases = (
+				9C9A708D2BAAAEB600EF9D0E /* Sources */,
+				9C9A708E2BAAAEB600EF9D0E /* Frameworks */,
+				9C9A708F2BAAAEB600EF9D0E /* Resources */,
+				9C9A70D92BAAE40B00EF9D0E /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "demo-app-tuvali";
+			packageProductDependencies = (
+				9C43FD132BB6AA7C001C5F6F /* ios-tuvali-library */,
+				9CF43DEE2BB6B556008CB8B1 /* ios-tuvali-library */,
+			);
+			productName = "demo-app-tuvali";
+			productReference = 9C9A70912BAAAEB600EF9D0E /* demo-app-tuvali.app */;
+			productType = "com.apple.product-type.application";
+		};
+		9C9A70A12BAAAEB900EF9D0E /* demo-app-tuvaliTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9C9A70B92BAAAEB900EF9D0E /* Build configuration list for PBXNativeTarget "demo-app-tuvaliTests" */;
+			buildPhases = (
+				9C9A709E2BAAAEB900EF9D0E /* Sources */,
+				9C9A709F2BAAAEB900EF9D0E /* Frameworks */,
+				9C9A70A02BAAAEB900EF9D0E /* Resources */,
+				9C9A70CF2BAADC8800EF9D0E /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9C9A70A42BAAAEB900EF9D0E /* PBXTargetDependency */,
+			);
+			name = "demo-app-tuvaliTests";
+			productName = "demo-app-tuvaliTests";
+			productReference = 9C9A70A22BAAAEB900EF9D0E /* demo-app-tuvaliTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9C9A70AB2BAAAEB900EF9D0E /* demo-app-tuvaliUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9C9A70BC2BAAAEB900EF9D0E /* Build configuration list for PBXNativeTarget "demo-app-tuvaliUITests" */;
+			buildPhases = (
+				9C9A70A82BAAAEB900EF9D0E /* Sources */,
+				9C9A70A92BAAAEB900EF9D0E /* Frameworks */,
+				9C9A70AA2BAAAEB900EF9D0E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9C9A70AE2BAAAEB900EF9D0E /* PBXTargetDependency */,
+			);
+			name = "demo-app-tuvaliUITests";
+			productName = "demo-app-tuvaliUITests";
+			productReference = 9C9A70AC2BAAAEB900EF9D0E /* demo-app-tuvaliUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9C9A70892BAAAEB600EF9D0E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1530;
+				LastUpgradeCheck = 1530;
+				TargetAttributes = {
+					9C9A70902BAAAEB600EF9D0E = {
+						CreatedOnToolsVersion = 15.3;
+					};
+					9C9A70A12BAAAEB900EF9D0E = {
+						CreatedOnToolsVersion = 15.3;
+						TestTargetID = 9C9A70902BAAAEB600EF9D0E;
+					};
+					9C9A70AB2BAAAEB900EF9D0E = {
+						CreatedOnToolsVersion = 15.3;
+						TestTargetID = 9C9A70902BAAAEB600EF9D0E;
+					};
+				};
+			};
+			buildConfigurationList = 9C9A708C2BAAAEB600EF9D0E /* Build configuration list for PBXProject "demo-app-tuvali" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9C9A70882BAAAEB600EF9D0E;
+			packageReferences = (
+				9CF43DED2BB6B556008CB8B1 /* XCLocalSwiftPackageReference "../.." */,
+			);
+			productRefGroup = 9C9A70922BAAAEB600EF9D0E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9C9A70902BAAAEB600EF9D0E /* demo-app-tuvali */,
+				9C9A70A12BAAAEB900EF9D0E /* demo-app-tuvaliTests */,
+				9C9A70AB2BAAAEB900EF9D0E /* demo-app-tuvaliUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9C9A708F2BAAAEB600EF9D0E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C9A709D2BAAAEB900EF9D0E /* Preview Assets.xcassets in Resources */,
+				9C9A70992BAAAEB900EF9D0E /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9C9A70A02BAAAEB900EF9D0E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9C9A70AA2BAAAEB900EF9D0E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9C9A708D2BAAAEB600EF9D0E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C9A70972BAAAEB600EF9D0E /* ContentView.swift in Sources */,
+				9C9A70952BAAAEB600EF9D0E /* demo_app_tuvaliApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9C9A709E2BAAAEB900EF9D0E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C9A70A72BAAAEB900EF9D0E /* demo_app_tuvaliTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9C9A70A82BAAAEB900EF9D0E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C9A70B32BAAAEB900EF9D0E /* demo_app_tuvaliUITestsLaunchTests.swift in Sources */,
+				9C9A70B12BAAAEB900EF9D0E /* demo_app_tuvaliUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9C9A70A42BAAAEB900EF9D0E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9C9A70902BAAAEB600EF9D0E /* demo-app-tuvali */;
+			targetProxy = 9C9A70A32BAAAEB900EF9D0E /* PBXContainerItemProxy */;
+		};
+		9C9A70AE2BAAAEB900EF9D0E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9C9A70902BAAAEB600EF9D0E /* demo-app-tuvali */;
+			targetProxy = 9C9A70AD2BAAAEB900EF9D0E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		9C9A70B42BAAAEB900EF9D0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		9C9A70B52BAAAEB900EF9D0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		9C9A70B72BAAAEB900EF9D0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "demo-app-tuvali/demo_app_tuvali.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"demo-app-tuvali/Preview Content\"";
+				DEVELOPMENT_TEAM = DGQ6355MH2;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Tuvali Demo uses Bluetooth to transfer verifiable credentials between wallet and verifier roles.";
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "inji.demo-app-tuvali";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9C9A70B82BAAAEB900EF9D0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "demo-app-tuvali/demo_app_tuvali.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"demo-app-tuvali/Preview Content\"";
+				DEVELOPMENT_TEAM = DGQ6355MH2;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Tuvali Demo uses Bluetooth to transfer verifiable credentials between wallet and verifier roles.";
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "inji.demo-app-tuvali";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		9C9A70BA2BAAAEB900EF9D0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				MACOSX_DEPLOYMENT_TARGET = 14.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "thoughtworks.demo-app-tuvaliTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/demo-app-tuvali.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/demo-app-tuvali";
+			};
+			name = Debug;
+		};
+		9C9A70BB2BAAAEB900EF9D0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				MACOSX_DEPLOYMENT_TARGET = 14.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "thoughtworks.demo-app-tuvaliTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/demo-app-tuvali.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/demo-app-tuvali";
+			};
+			name = Release;
+		};
+		9C9A70BD2BAAAEB900EF9D0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				MACOSX_DEPLOYMENT_TARGET = 14.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "thoughtworks.demo-app-tuvaliUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "demo-app-tuvali";
+			};
+			name = Debug;
+		};
+		9C9A70BE2BAAAEB900EF9D0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				MACOSX_DEPLOYMENT_TARGET = 14.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "thoughtworks.demo-app-tuvaliUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "demo-app-tuvali";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9C9A708C2BAAAEB600EF9D0E /* Build configuration list for PBXProject "demo-app-tuvali" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C9A70B42BAAAEB900EF9D0E /* Debug */,
+				9C9A70B52BAAAEB900EF9D0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9C9A70B62BAAAEB900EF9D0E /* Build configuration list for PBXNativeTarget "demo-app-tuvali" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C9A70B72BAAAEB900EF9D0E /* Debug */,
+				9C9A70B82BAAAEB900EF9D0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9C9A70B92BAAAEB900EF9D0E /* Build configuration list for PBXNativeTarget "demo-app-tuvaliTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C9A70BA2BAAAEB900EF9D0E /* Debug */,
+				9C9A70BB2BAAAEB900EF9D0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9C9A70BC2BAAAEB900EF9D0E /* Build configuration list for PBXNativeTarget "demo-app-tuvaliUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C9A70BD2BAAAEB900EF9D0E /* Debug */,
+				9C9A70BE2BAAAEB900EF9D0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		9CF43DED2BB6B556008CB8B1 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9C43FD132BB6AA7C001C5F6F /* ios-tuvali-library */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "ios-tuvali-library";
+		};
+		9CF43DEE2BB6B556008CB8B1 /* ios-tuvali-library */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "ios-tuvali-library";
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 9C9A70892BAAAEB600EF9D0E /* Project object */;
+}

--- a/example/demo-ios-app/demo-app-tuvali.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example/demo-ios-app/demo-app-tuvali.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/example/demo-ios-app/demo-app-tuvali.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/demo-ios-app/demo-app-tuvali.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "cadae1650a14434e5422a34eeb3d2be02bc8d52f848320e61f4892f26ec76f55",
+  "pins" : [
+    {
+      "identity" : "crcswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ivanesik/CrcSwift.git",
+      "state" : {
+        "revision" : "bb2fff7fb79815fad0528da71c9168d570bfc76c",
+        "version" : "0.0.3"
+      }
+    },
+    {
+      "identity" : "gzipswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/1024jp/GzipSwift",
+      "state" : {
+        "revision" : "7a7f17761c76a932662ab77028a4329f67d645a4",
+        "version" : "5.2.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/example/demo-ios-app/demo-app-tuvali/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/example/demo-ios-app/demo-app-tuvali/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example/demo-ios-app/demo-app-tuvali/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/example/demo-ios-app/demo-app-tuvali/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,63 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example/demo-ios-app/demo-app-tuvali/Assets.xcassets/Contents.json
+++ b/example/demo-ios-app/demo-app-tuvali/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example/demo-ios-app/demo-app-tuvali/ContentView.swift
+++ b/example/demo-ios-app/demo-app-tuvali/ContentView.swift
@@ -1,0 +1,428 @@
+import SwiftUI
+import ios_tuvali_library
+import UIKit
+
+struct ContentView: View {
+    @State private var selectedRole: DemoRole = .verifier
+    @State private var verifierName = "TUVALI-IOS"
+    @State private var verifierURI = ""
+    @State private var walletURI = ""
+    @State private var payload = "{\"credential\":\"sample-vp\",\"issuedAt\":\"2026-04-25\"}"
+    @State private var receivedPayload = "Waiting for wallet data"
+    @State private var activityLog: [String] = ["Ready"]
+
+    private let wallet = Wallet()
+    private let verifier = Verifier()
+
+    var body: some View {
+        ZStack {
+            AppBackground()
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 22) {
+                    HeaderView()
+
+                    RoleSwitch(selectedRole: $selectedRole)
+
+                    if selectedRole == .verifier {
+                        verifierPanel
+                            .transition(.move(edge: .leading).combined(with: .opacity))
+                    } else {
+                        walletPanel
+                            .transition(.move(edge: .trailing).combined(with: .opacity))
+                    }
+
+                    LogPanel(entries: activityLog)
+                }
+                .padding(20)
+            }
+        }
+        .animation(.spring(response: 0.45, dampingFraction: 0.82), value: selectedRole)
+        .onAppear(perform: subscribeToTuvaliEvents)
+    }
+
+    private var verifierPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            PanelTitle(icon: "dot.radiowaves.left.and.right", title: "Verifier Station", subtitle: "Advertise this phone and receive a VP over BLE.")
+
+            LabeledField(title: "Verifier name", text: $verifierName, prompt: "STADONENTRY")
+
+            Button(action: startVerifier) {
+                PrimaryButtonLabel(title: "Start verifier", icon: "antenna.radiowaves.left.and.right")
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            if !verifierURI.isEmpty {
+                URIBlock(title: "Share this URI", value: verifierURI, actionTitle: "Copy URI") {
+                    UIPasteboard.general.string = verifierURI
+                    appendLog("Verifier URI copied")
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Received payload")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                Text(receivedPayload)
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.78))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(14)
+                    .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+
+            HStack(spacing: 12) {
+                Button("Accept") {
+                    verifier.sendVerificationStatus(.ACCEPTED)
+                    appendLog("Verifier sent ACCEPTED")
+                }
+                .buttonStyle(StatusButtonStyle(tint: .green))
+
+                Button("Reject") {
+                    verifier.sendVerificationStatus(.REJECTED)
+                    appendLog("Verifier sent REJECTED")
+                }
+                .buttonStyle(StatusButtonStyle(tint: .red))
+            }
+        }
+        .panelStyle()
+    }
+
+    private var walletPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            PanelTitle(icon: "wallet.pass", title: "Wallet Console", subtitle: "Paste a verifier URI, connect, then send encrypted data.")
+
+            LabeledMultilineField(title: "Verifier URI", text: $walletURI, prompt: "OPENID4VP://connect?name=...&key=...")
+
+            HStack(spacing: 12) {
+                Button(action: pasteURI) {
+                    SecondaryButtonLabel(title: "Paste", icon: "doc.on.clipboard")
+                }
+                .buttonStyle(SecondaryButtonStyle())
+
+                Button(action: startWallet) {
+                    PrimaryButtonLabel(title: "Connect", icon: "link")
+                }
+                .buttonStyle(PrimaryButtonStyle())
+            }
+
+            LabeledMultilineField(title: "Payload", text: $payload, prompt: "Credential or VP payload")
+
+            Button(action: sendPayload) {
+                PrimaryButtonLabel(title: "Send payload", icon: "paperplane.fill")
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button("Disconnect wallet") {
+                wallet.disconnect()
+                appendLog("Wallet disconnect requested")
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
+        .panelStyle()
+    }
+
+    private func subscribeToTuvaliEvents() {
+        wallet.subscribe(handleEvent)
+        verifier.subscribe(handleEvent)
+    }
+
+    private func startVerifier() {
+        verifierURI = verifier.startAdvertisement(verifierName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "TUVALI-IOS" : verifierName)
+        UIPasteboard.general.string = verifierURI
+        walletURI = verifierURI
+        appendLog("Verifier advertising started")
+    }
+
+    private func pasteURI() {
+        walletURI = UIPasteboard.general.string ?? walletURI
+        appendLog("URI pasted")
+    }
+
+    private func startWallet() {
+        wallet.startConnection(walletURI)
+        appendLog("Wallet connection started")
+    }
+
+    private func sendPayload() {
+        wallet.send(payload)
+        appendLog("Wallet sent payload request")
+    }
+
+    private func handleEvent(_ event: Event) {
+        DispatchQueue.main.async {
+            switch event {
+            case is ConnectedEvent:
+                appendLog("BLE connected")
+            case is SecureChannelEstablishedEvent:
+                appendLog("Secure channel established")
+            case is DataSentEvent:
+                appendLog("Wallet data sent")
+            case let dataEvent as DataReceivedEvent:
+                receivedPayload = dataEvent.data
+                appendLog("Verifier received data: \(dataEvent.totalChunkCount) chunks")
+            case let statusEvent as VerificationStatusEvent:
+                appendLog("Wallet received status: \(statusEvent.status == .ACCEPTED ? "ACCEPTED" : "REJECTED")")
+            case let errorEvent as ErrorEvent:
+                appendLog("Error \(errorEvent.code): \(errorEvent.message)")
+            case is DisconnectedEvent:
+                appendLog("BLE disconnected")
+            default:
+                appendLog("Event: \(String(describing: type(of: event)))")
+            }
+        }
+    }
+
+    private func appendLog(_ message: String) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        activityLog.insert("\(formatter.string(from: Date()))  \(message)", at: 0)
+        activityLog = Array(activityLog.prefix(8))
+    }
+}
+
+enum DemoRole: String, CaseIterable, Identifiable {
+    case verifier = "Verifier"
+    case wallet = "Wallet"
+
+    var id: String { rawValue }
+}
+
+struct HeaderView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Tuvali BLE Lab")
+                .font(.system(size: 42, weight: .black, design: .rounded))
+                .foregroundStyle(.white)
+            Text("Run this device as a verifier or wallet and test encrypted local transfer over Bluetooth Low Energy.")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.white.opacity(0.72))
+        }
+        .padding(.top, 18)
+    }
+}
+
+struct RoleSwitch: View {
+    @Binding var selectedRole: DemoRole
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(DemoRole.allCases) { role in
+                Button {
+                    selectedRole = role
+                } label: {
+                    Text(role.rawValue)
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 13)
+                        .foregroundStyle(selectedRole == role ? .black : .white.opacity(0.78))
+                        .background(selectedRole == role ? Color.white : Color.white.opacity(0.1), in: Capsule())
+                }
+            }
+        }
+        .padding(6)
+        .background(.white.opacity(0.08), in: Capsule())
+    }
+}
+
+struct PanelTitle: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: icon)
+                .font(.title2.weight(.bold))
+                .foregroundStyle(.black)
+                .frame(width: 48, height: 48)
+                .background(Color.white, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.title2.bold())
+                    .foregroundStyle(.white)
+                Text(subtitle)
+                    .font(.callout)
+                    .foregroundStyle(.white.opacity(0.68))
+            }
+        }
+    }
+}
+
+struct LabeledField: View {
+    let title: String
+    @Binding var text: String
+    let prompt: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.subheadline.bold()).foregroundStyle(.white.opacity(0.82))
+            TextField(prompt, text: $text)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding(14)
+                .background(.white.opacity(0.1), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+struct LabeledMultilineField: View {
+    let title: String
+    @Binding var text: String
+    let prompt: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.subheadline.bold()).foregroundStyle(.white.opacity(0.82))
+            TextEditor(text: $text)
+                .font(.system(.callout, design: .monospaced))
+                .frame(minHeight: 104)
+                .scrollContentBackground(.hidden)
+                .padding(10)
+                .background(.white.opacity(0.1), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .foregroundStyle(.white)
+                .overlay(alignment: .topLeading) {
+                    if text.isEmpty {
+                        Text(prompt)
+                            .font(.system(.callout, design: .monospaced))
+                            .foregroundStyle(.white.opacity(0.35))
+                            .padding(18)
+                    }
+                }
+        }
+    }
+}
+
+struct URIBlock: View {
+    let title: String
+    let value: String
+    let actionTitle: String
+    let action: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title).font(.headline).foregroundStyle(.white)
+            Text(value)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.78))
+                .textSelection(.enabled)
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.black.opacity(0.2), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            Button(actionTitle, action: action)
+                .buttonStyle(SecondaryButtonStyle())
+        }
+    }
+}
+
+struct LogPanel: View {
+    let entries: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Session log")
+                .font(.headline)
+                .foregroundStyle(.white)
+            ForEach(entries, id: \.self) { entry in
+                Text(entry)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.72))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .panelStyle()
+    }
+}
+
+struct AppBackground: View {
+    var body: some View {
+        LinearGradient(colors: [Color(red: 0.02, green: 0.08, blue: 0.13), Color(red: 0.05, green: 0.20, blue: 0.22), Color(red: 0.04, green: 0.04, blue: 0.08)], startPoint: .topLeading, endPoint: .bottomTrailing)
+            .ignoresSafeArea()
+            .overlay(alignment: .topTrailing) {
+                Circle()
+                    .fill(Color.teal.opacity(0.28))
+                    .frame(width: 260, height: 260)
+                    .blur(radius: 34)
+                    .offset(x: 90, y: -80)
+            }
+            .overlay(alignment: .bottomLeading) {
+                RoundedRectangle(cornerRadius: 80, style: .continuous)
+                    .fill(Color.orange.opacity(0.13))
+                    .frame(width: 240, height: 240)
+                    .rotationEffect(.degrees(22))
+                    .blur(radius: 18)
+                    .offset(x: -90, y: 120)
+            }
+    }
+}
+
+struct PrimaryButtonLabel: View {
+    let title: String
+    let icon: String
+
+    var body: some View {
+        Label(title, systemImage: icon)
+            .font(.headline)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 15)
+    }
+}
+
+struct SecondaryButtonLabel: View {
+    let title: String
+    let icon: String
+
+    var body: some View {
+        Label(title, systemImage: icon)
+            .font(.headline)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 15)
+    }
+}
+
+struct PrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(.black)
+            .background(Color.white.opacity(configuration.isPressed ? 0.72 : 1), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+}
+
+struct SecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(.white)
+            .background(.white.opacity(configuration.isPressed ? 0.08 : 0.14), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+}
+
+struct StatusButtonStyle: ButtonStyle {
+    let tint: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .foregroundStyle(.white)
+            .background(tint.opacity(configuration.isPressed ? 0.46 : 0.74), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+extension View {
+    func panelStyle() -> some View {
+        self
+            .padding(18)
+            .background(.white.opacity(0.09), in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .stroke(.white.opacity(0.12), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.28), radius: 24, y: 18)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/example/demo-ios-app/demo-app-tuvali/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/example/demo-ios-app/demo-app-tuvali/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example/demo-ios-app/demo-app-tuvali/demo_app_tuvali.entitlements
+++ b/example/demo-ios-app/demo-app-tuvali/demo_app_tuvali.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/example/demo-ios-app/demo-app-tuvali/demo_app_tuvaliApp.swift
+++ b/example/demo-ios-app/demo-app-tuvali/demo_app_tuvaliApp.swift
@@ -1,0 +1,21 @@
+//
+//  demo_app_tuvaliApp.swift
+//  demo-app-tuvali
+//
+//  Created by Abhishek Paul on 20/03/24.
+//
+
+import SwiftUI
+
+@main
+struct demo_app_tuvaliApp: App {
+    
+    var body: some Scene {
+        
+        
+        WindowGroup {
+            ContentView()
+            
+        }
+    }
+}


### PR DESCRIPTION
This PR adds iOS verifier support to the Tuvali iOS library. It implements the Verifier role over Bluetooth Low Energy (BLE), enabling BLE advertising, secure ECDH key exchange, session setup, and chunked payload transfer/reception.

### Key Changes
- Introduced `Verifier` class and `VerifierBleCommunicator` to handle BLE advertisements and communication.
- Implemented `VerifierTransferHandler` to handle key exchange and VC/VP reception.
- Added a fallback local name discovery mechanism for iOS-to-iOS connection support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Verifier mode now supports BLE advertisement generation and verification status management
  - Wallet mode can establish BLE connections with verifiers using OpenID4VP URIs
  - Event-driven notifications for connection state, data reception, and system errors
  - Comprehensive demo application showcasing both Verifier and Wallet modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inji/tuvali-ios-swift/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->