### PR TITLE
ci(workflow): pin push-trigger build job to macos-14

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build-swift:
-    runs-on: macos-latest
+    runs-on: macos-14
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Pins the `build-swift` job in `.github/workflows/push-trigger.yml` to the `macos-14` runner instead of `macos-latest`, so CI builds run on a fixed Xcode/macOS image rather than shifting when GitHub moves the `latest` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Swift build environment to use a fixed macOS 14 runner, improving build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->